### PR TITLE
Typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ compiler.set_name(varying_resource.base_type_id, "VertexFragmentLinkage");
 ```
 
 Some platform may require identical variable name for both vertex outputs and fragment inputs. (for example MacOSX)
-to rename varaible base on location, please add
+to rename variable base on location, please add
 ```
 --rename-interface-variable <in|out> <location> <new_variable_name>
 ```


### PR DESCRIPTION
There is a typo at line 324. variable is misspelled as varaible.  